### PR TITLE
stop using fat arrow function so it can be used with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-relative-date",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Tiny function that provides relative, human-readable dates.",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,4 +1,6 @@
-const calculateDelta = (now, date) => Math.round(Math.abs(now - date) / 1000)
+function calculateDelta(now, date){
+  return Math.round(Math.abs(now - date) / 1000)
+}
 
 export default function relativeDateFactory (translations) {
   return function relativeDate (date, now = new Date()) {


### PR DESCRIPTION
See here for why https://github.com/facebookincubator/create-react-app/issues/3529